### PR TITLE
Fixing the correct versions of the package for older Laravels

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,7 @@ existing routes.
   composer require genealabs/laravel-mixpanel:~0.5.1
   ```
 
-  For Laravel 5.0.x through 5.1.x:
-  ```sh
-  composer require genealabs/laravel-mixpanel:0.4.14
-  ```
+  For Laravel 5.1.x you should require version 0.4.14; for 5.0.x, version 0.2.13.
 
 2. Add the service provider entry in `config\app.php`:
   ```php


### PR DESCRIPTION
Since 0.3.* it requires routing `^5.1` :(
The last version requiring 5.0 is 0.2.13 (and yes, I'm on an outdated project that has no time for upgrades right now).