### PR TITLE
Resolve routing depreciation in Laravel v5.3

### DIFF
--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -3,4 +3,4 @@
 use GeneaLabs\LaravelMixpanel\Http\Controllers\StripeWebhooksController;
 use Illuminate\Support\Facades\View;
 
-Route::controller('genealabs/laravel-mixpanel/stripe', StripeWebhooksController::class);
+Route::post('genealabs/laravel-mixpanel/stripe', ['uses' => 'GeneaLabs\LaravelMixpanel\Http\Controllers\StripeWebhooksController@postTransaction']);


### PR DESCRIPTION
This will remove the Route::controller() call and replace it with an explicit route call.

Fixes #17