### PR TITLE
Fixed tracking canceled subscription for Stripe

### DIFF
--- a/src/Http/Requests/RecordStripeEvent.php
+++ b/src/Http/Requests/RecordStripeEvent.php
@@ -91,10 +91,10 @@ class RecordStripeEvent extends FormRequest
         if ($planStatus === 'canceled') {
             $profileData = [
                 'Subscription' => 'None',
-                'Churned' => (new Carbon($transaction['canceled_at']))->format('Y-m-d\Th:i:s'),
+                'Churned' => Carbon::createFromTimestamp($transaction['canceled_at'])->format('Y-m-d\Th:i:s'),
                 'Plan When Churned' => $planName,
                 'Paid Lifetime' => (new Carbon)->createFromTimestampUTC($planStart)
-                    ->diffInDays((new Carbon(timestamp($transaction['ended_at'])))
+                    ->diffInDays(Carbon::createFromTimestamp($transaction['ended_at'])
                         ->timezone('UTC')) . ' days'
             ];
             $trackingData = [


### PR DESCRIPTION
Stripe API for Canceling subscription event send canceled_at field with a timestamp like this:

`"canceled_at": 1534001486,`

That is why line 94 in `src/Http/Requests/RecordStripeEvent.php`
`'Churned' => (new Carbon($transaction['canceled_at']))->format('Y-m-d\Th:i:s'),`

produces this error:

`DateTime::__construct(): Failed to parse time string (1534001486) at position 8 (8): Unexpected character`

Another issue is on line 97 when there is a call to an undefined function
and we get this error:

`Call to undefined function GeneaLabs\LaravelMixpanel\Http\Requests\timestamp()`
The error I mentioned in this issue: #48 

This fix works with latest Stripe API.
