### PR TITLE
PR to add the ability to configure the API host via the services config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ MIXPANEL_TOKEN=xxxxxxxxxxxxxxxxxxxxxx
 
 ## Configuration
 ### Default Values
+- `services.mixpanel.host`: (default: api.mixpanel.com) the api host to use.
 - `services.mixpanel.token`: pulls the 'MIXPANEL_TOKEN' value from your `.env`
  file.
 - `services.mixpanel.enable-default-tracking`: (default: true) enable or disable Laravel user

--- a/config/services.php
+++ b/config/services.php
@@ -2,6 +2,7 @@
 
 return [
     'mixpanel' => [
+        'host' => 'api.mixpanel.com',
         'token' => env('MIXPANEL_TOKEN'),
         'enable-default-tracking' => true,
         'consumer' => 'socket',

--- a/src/LaravelMixpanel.php
+++ b/src/LaravelMixpanel.php
@@ -19,6 +19,7 @@ class LaravelMixpanel extends Mixpanel
     {
         $this->callbackResults = [];
         $this->defaults = [
+            'host' => config('services.mixpanel.host', 'api.mixpanel.com'),
             'consumer' => config('services.mixpanel.consumer', 'socket'),
             'connect_timeout' => config('services.mixpanel.connect-timeout', 2),
             'timeout' => config('services.mixpanel.timeout', 2),


### PR DESCRIPTION
This PR will add the ability to override the default API host via the services config file predominantly to enable european users to use the `api-eu.mixpanel.com` host.