### PR TITLE
Adds the ability to define a getMixPanelKey method on the user class …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "require-dev": {
         "fzaninotto/faker": "^1.8",
         "laravel/laravel": "^7.0",
+        "laravel/ui": "^2.0",
         "laravel/browser-kit-testing": "^6.0",
         "phpmd/phpmd": "^2.7",
         "phpunit/phpunit": "^8.5",

--- a/src/Listeners/MixpanelEvent.php
+++ b/src/Listeners/MixpanelEvent.php
@@ -10,11 +10,18 @@ class MixpanelEvent
         $user = $event->user;
 
         if ($user && config("services.mixpanel.enable-default-tracking")) {
+
+            $userKey = $user->getKey();
+
+            if (method_exists($user, 'getMixPanelKey')) {
+                $userKey = $user->getMixPanelKey();
+            }
+
             $profileData = $this->getProfileData($user);
             $profileData = array_merge($profileData, $event->profileData);
 
-            app('mixpanel')->identify($user->getKey());
-            app('mixpanel')->people->set($user->getKey(), $profileData, request()->ip());
+            app('mixpanel')->identify($userKey);
+            app('mixpanel')->people->set($userKey, $profileData, request()->ip());
 
             if ($event->charge !== 0) {
                 app('mixpanel')->people->trackCharge($user->id, $event->charge);

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -17,6 +17,7 @@ trait CreatesApplication
             __DIR__ . '/Fixtures/resources/views/auth/passwords/reset.blade.php' => __DIR__ . '/../vendor/laravel/laravel/resources/views/auth/passwords/email.blade.php',
             __DIR__ . '/Fixtures/resources/views/layouts/app.blade.php' => __DIR__ . '/../vendor/laravel/laravel/resources/views/layouts/app.blade.php',
             __DIR__ . '/Fixtures/routes/web.php' => __DIR__ . '/../vendor/laravel/laravel/routes/web.php',
+            __DIR__ . '/Fixtures/config/app.php' => __DIR__ . '/../vendor/laravel/laravel/config/app.php',
         ]);
         $app = require __DIR__ . '/../vendor/laravel/laravel/bootstrap/app.php';
         $app->make(Kernel::class)->bootstrap();

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -1,9 +1,11 @@
 <?php namespace GeneaLabs\LaravelMixpanel\Tests\Feature;
 
 use App\User;
+use GeneaLabs\LaravelMixpanel\Facades\Mixpanel;
 use GeneaLabs\LaravelMixpanel\Tests\FeatureTestCase;
 use GeneaLabs\LaravelMixpanel\Listeners\LoginAttempt;
 use GeneaLabs\LaravelMixpanel\Events\MixpanelEvent;
+use GeneaLabs\LaravelMixpanel\Tests\Fixtures\App\UserWithMixKey;
 use Illuminate\Auth\Events\Attempting;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Logout;
@@ -65,5 +67,33 @@ class AuthenticationTest extends FeatureTestCase
         Event::assertDispatched(MixpanelEvent::class, function ($event) use ($user) {
             return ($event->user->email === $user->email && $event->names()->contains('User Logged Out'));
         });
+    }
+
+    public function testUsingAlternateKey()
+    {
+        $spy = Mixpanel::spy();
+        $spy->people = new \Producers_MixpanelPeople([]);
+
+        $user = UserWithMixKey::create([
+            'name'     => 'Test User',
+            'email'    => 'tester@testing.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        event(new MixpanelEvent($user, ['User Logged In' => []]));
+
+        $spy->shouldHaveReceived('identify')->with('random-other-identifier');
+    }
+
+    public function testUsingDefaultKey()
+    {
+        $spy = Mixpanel::spy();
+        $spy->people = new \Producers_MixpanelPeople([]);
+
+        $user = factory(User::class)->create();
+
+        event(new MixpanelEvent($user, ['User Logged In' => []]));
+
+        $spy->shouldHaveReceived('identify')->with($user->id);
     }
 }

--- a/tests/Fixtures/App/UserWithMixKey.php
+++ b/tests/Fixtures/App/UserWithMixKey.php
@@ -1,0 +1,11 @@
+<?php namespace GeneaLabs\LaravelMixpanel\Tests\Fixtures\App;
+
+class UserWithMixKey extends User
+{
+    protected $table = 'users';
+
+    public function getMixPanelKey()
+    {
+        return 'random-other-identifier';
+    }
+}

--- a/tests/Fixtures/config/app.php
+++ b/tests/Fixtures/config/app.php
@@ -1,0 +1,233 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Name
+    |--------------------------------------------------------------------------
+    |
+    | This value is the name of your application. This value is used when the
+    | framework needs to place the application's name in a notification or
+    | any other location as required by the application or its packages.
+    |
+    */
+
+    'name' => env('APP_NAME', 'Laravel'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Environment
+    |--------------------------------------------------------------------------
+    |
+    | This value determines the "environment" your application is currently
+    | running in. This may determine how you prefer to configure various
+    | services the application utilizes. Set this in your ".env" file.
+    |
+    */
+
+    'env' => env('APP_ENV', 'production'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Debug Mode
+    |--------------------------------------------------------------------------
+    |
+    | When your application is in debug mode, detailed error messages with
+    | stack traces will be shown on every error that occurs within your
+    | application. If disabled, a simple generic error page is shown.
+    |
+    */
+
+    'debug' => (bool) env('APP_DEBUG', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application URL
+    |--------------------------------------------------------------------------
+    |
+    | This URL is used by the console to properly generate URLs when using
+    | the Artisan command line tool. You should set this to the root of
+    | your application so that it is used when running Artisan tasks.
+    |
+    */
+
+    'url' => env('APP_URL', 'http://localhost'),
+
+    'asset_url' => env('ASSET_URL', null),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Timezone
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the default timezone for your application, which
+    | will be used by the PHP date and date-time functions. We have gone
+    | ahead and set this to a sensible default for you out of the box.
+    |
+    */
+
+    'timezone' => 'UTC',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Locale Configuration
+    |--------------------------------------------------------------------------
+    |
+    | The application locale determines the default locale that will be used
+    | by the translation service provider. You are free to set this value
+    | to any of the locales which will be supported by the application.
+    |
+    */
+
+    'locale' => 'en',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Fallback Locale
+    |--------------------------------------------------------------------------
+    |
+    | The fallback locale determines the locale to use when the current one
+    | is not available. You may change the value to correspond to any of
+    | the language folders that are provided through your application.
+    |
+    */
+
+    'fallback_locale' => 'en',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Faker Locale
+    |--------------------------------------------------------------------------
+    |
+    | This locale will be used by the Faker PHP library when generating fake
+    | data for your database seeds. For example, this will be used to get
+    | localized telephone numbers, street address information and more.
+    |
+    */
+
+    'faker_locale' => 'en_US',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Encryption Key
+    |--------------------------------------------------------------------------
+    |
+    | This key is used by the Illuminate encrypter service and should be set
+    | to a random, 32 character string, otherwise these encrypted strings
+    | will not be safe. Please do this before deploying an application!
+    |
+    */
+
+    'key' => env('APP_KEY'),
+
+    'cipher' => 'AES-256-CBC',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Autoloaded Service Providers
+    |--------------------------------------------------------------------------
+    |
+    | The service providers listed here will be automatically loaded on the
+    | request to your application. Feel free to add your own services to
+    | this array to grant expanded functionality to your applications.
+    |
+    */
+
+    'providers' => [
+
+        /*
+         * Laravel Framework Service Providers...
+         */
+        Illuminate\Auth\AuthServiceProvider::class,
+        Illuminate\Broadcasting\BroadcastServiceProvider::class,
+        Illuminate\Bus\BusServiceProvider::class,
+        Illuminate\Cache\CacheServiceProvider::class,
+        Illuminate\Foundation\Providers\ConsoleSupportServiceProvider::class,
+        Illuminate\Cookie\CookieServiceProvider::class,
+        Illuminate\Database\DatabaseServiceProvider::class,
+        Illuminate\Encryption\EncryptionServiceProvider::class,
+        Illuminate\Filesystem\FilesystemServiceProvider::class,
+        Illuminate\Foundation\Providers\FoundationServiceProvider::class,
+        Illuminate\Hashing\HashServiceProvider::class,
+        Illuminate\Mail\MailServiceProvider::class,
+        Illuminate\Notifications\NotificationServiceProvider::class,
+        Illuminate\Pagination\PaginationServiceProvider::class,
+        Illuminate\Pipeline\PipelineServiceProvider::class,
+        Illuminate\Queue\QueueServiceProvider::class,
+        Illuminate\Redis\RedisServiceProvider::class,
+        Illuminate\Auth\Passwords\PasswordResetServiceProvider::class,
+        Illuminate\Session\SessionServiceProvider::class,
+        Illuminate\Translation\TranslationServiceProvider::class,
+        Illuminate\Validation\ValidationServiceProvider::class,
+        Illuminate\View\ViewServiceProvider::class,
+        Laravel\Ui\UiServiceProvider::class,
+
+        /*
+         * Package Service Providers...
+         */
+
+        /*
+         * Application Service Providers...
+         */
+        App\Providers\AppServiceProvider::class,
+        App\Providers\AuthServiceProvider::class,
+        // App\Providers\BroadcastServiceProvider::class,
+        App\Providers\EventServiceProvider::class,
+        App\Providers\RouteServiceProvider::class,
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Class Aliases
+    |--------------------------------------------------------------------------
+    |
+    | This array of class aliases will be registered when this application
+    | is started. However, feel free to register as many as you wish as
+    | the aliases are "lazy" loaded so they don't hinder performance.
+    |
+    */
+
+    'aliases' => [
+
+        'App' => Illuminate\Support\Facades\App::class,
+        'Arr' => Illuminate\Support\Arr::class,
+        'Artisan' => Illuminate\Support\Facades\Artisan::class,
+        'Auth' => Illuminate\Support\Facades\Auth::class,
+        'Blade' => Illuminate\Support\Facades\Blade::class,
+        'Broadcast' => Illuminate\Support\Facades\Broadcast::class,
+        'Bus' => Illuminate\Support\Facades\Bus::class,
+        'Cache' => Illuminate\Support\Facades\Cache::class,
+        'Config' => Illuminate\Support\Facades\Config::class,
+        'Cookie' => Illuminate\Support\Facades\Cookie::class,
+        'Crypt' => Illuminate\Support\Facades\Crypt::class,
+        'DB' => Illuminate\Support\Facades\DB::class,
+        'Eloquent' => Illuminate\Database\Eloquent\Model::class,
+        'Event' => Illuminate\Support\Facades\Event::class,
+        'File' => Illuminate\Support\Facades\File::class,
+        'Gate' => Illuminate\Support\Facades\Gate::class,
+        'Hash' => Illuminate\Support\Facades\Hash::class,
+        'Http' => Illuminate\Support\Facades\Http::class,
+        'Lang' => Illuminate\Support\Facades\Lang::class,
+        'Log' => Illuminate\Support\Facades\Log::class,
+        'Mail' => Illuminate\Support\Facades\Mail::class,
+        'Notification' => Illuminate\Support\Facades\Notification::class,
+        'Password' => Illuminate\Support\Facades\Password::class,
+        'Queue' => Illuminate\Support\Facades\Queue::class,
+        'Redirect' => Illuminate\Support\Facades\Redirect::class,
+        'Redis' => Illuminate\Support\Facades\Redis::class,
+        'Request' => Illuminate\Support\Facades\Request::class,
+        'Response' => Illuminate\Support\Facades\Response::class,
+        'Route' => Illuminate\Support\Facades\Route::class,
+        'Schema' => Illuminate\Support\Facades\Schema::class,
+        'Session' => Illuminate\Support\Facades\Session::class,
+        'Storage' => Illuminate\Support\Facades\Storage::class,
+        'Str' => Illuminate\Support\Str::class,
+        'URL' => Illuminate\Support\Facades\URL::class,
+        'Validator' => Illuminate\Support\Facades\Validator::class,
+        'View' => Illuminate\Support\Facades\View::class,
+
+    ],
+
+];


### PR DESCRIPTION
Adds the ability to define a getMixPanelKey method on the user class to use for the identifier

- Addresses [Issue 54](https://github.com/GeneaLabs/laravel-mixpanel/issues/54)
- Adds tests for default identifier and alternative identifier
- Updates composer to add laravel/ui which is now needed for Auth routes
- Adds config in Fixtures to load the Laravel\UI\UiServiceProvider for Auth routes

Fixes #120