### PR TITLE
Provides support for the Mixpanel 'debug' state

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -8,6 +8,7 @@ return [
         'consumer' => 'socket',
         'connect-timeout' => 2,
         'timeout' => 2,
-        "data_callback_class" => null,
+        'data_callback_class' => null,
+        'debug' => env('MIXPANEL_DEBUG', false),
     ]
 ];

--- a/src/LaravelMixpanel.php
+++ b/src/LaravelMixpanel.php
@@ -22,6 +22,7 @@ class LaravelMixpanel extends Mixpanel
             'consumer' => config('services.mixpanel.consumer', 'socket'),
             'connect_timeout' => config('services.mixpanel.connect-timeout', 2),
             'timeout' => config('services.mixpanel.timeout', 2),
+            'debug' => config('services.mixpanel.debug', false),
         ];
 
         if (config('services.mixpanel.host')) {


### PR DESCRIPTION
This PR expands upon the config and 'defaults' of the Mixpanel object construction to pass through the 'debug' argument to the dependent mixpanel library.

I've found myself needing to use 'debug' in order to effectively test my implementation, but wasn't able to readily turn the state off or on using this library.

Essentially, Mixpanel's base consumer class will post an error or info message to the PHP error log in the event that the debug argument is supplied as `true`

The argument I added to the config/env and the mixpanel constructor always defaults to `false` and it's therefore fully backwards compatible.