### PR TITLE
Use Cashier Model config variable

### DIFF
--- a/src/Http/Requests/RecordStripeEvent.php
+++ b/src/Http/Requests/RecordStripeEvent.php
@@ -31,7 +31,7 @@ class RecordStripeEvent extends FormRequest
             ? $data['data']['previous_attributes']
             : [];
         $stripeCustomerId = $this->findStripeCustomerId($transaction);
-        $authModel = config('auth.providers.users.model') ?? config('auth.model');
+        $authModel = config('cashier.model') ?? config('auth.providers.users.model') ?? config('auth.model');
         $user = app($authModel)->where('stripe_id', $stripeCustomerId)->first();
 
         if (! $user) {

--- a/src/Providers/Service.php
+++ b/src/Providers/Service.php
@@ -29,7 +29,6 @@ class Service extends EventServiceProvider
     public function boot()
     {
         parent::boot();
-
         include __DIR__ . '/../../routes/api.php';
 
         $this->loadViewsFrom(__DIR__ . '/../../resources/views', 'genealabs-laravel-mixpanel');
@@ -45,6 +44,8 @@ class Service extends EventServiceProvider
 
     public function register()
     {
+        parent::register();
+        
         $this->mergeConfigFrom(__DIR__ . '/../../config/services.php', 'services');
         $this->commands(Publish::class);
         $this->app->singleton('mixpanel', LaravelMixpanel::class);


### PR DESCRIPTION
This PR allows laravel-mixpanel to use a custom Cashier model when receiving webhooks from Stripe.

Closes #90