### PR TITLE
BUGFIX - Laravel 8 event listeners not working 

### DIFF
--- a/src/Providers/Service.php
+++ b/src/Providers/Service.php
@@ -45,6 +45,8 @@ class Service extends EventServiceProvider
 
     public function register()
     {
+        parent::register();
+        
         $this->mergeConfigFrom(__DIR__ . '/../../config/services.php', 'services');
         $this->commands(Publish::class);
         $this->app->singleton('mixpanel', LaravelMixpanel::class);


### PR DESCRIPTION
This PR responds to the changes in Laravel 8 whereby a Service Provider that registers listeners now needs to call the parent register method.
